### PR TITLE
Replace GNU parallel with tee

### DIFF
--- a/scripts/QC.sh
+++ b/scripts/QC.sh
@@ -143,7 +143,7 @@ function biscuitQC {
         tmp_dir=$(mktemp -d -p ${outdir})
         mkfifo "$tmp_dir/f1" "$tmp_dir/f2"
         
-        # Set up the four processing pipelines, each reading data from one of these named pipes
+        # Set up the processing pipelines, each reading data from one of these named pipes
         # We also need to collect the PID for each process, so that we don't continue with the script before these processes finish
         (bedtools intersect -sorted -wo -b ${outdir}/${sample}_genomecov_all.tmp.bed -a stdin < "$tmp_dir/f1" | bedtools groupby -g 1-3 -c 7 -o min > ${outdir}/${sample}_cpg_all.tmp.bed) & pid1=$!
         (bedtools intersect -sorted -wo -b ${outdir}/${sample}_genomecov_q40.tmp.bed -a stdin < "$tmp_dir/f2" | bedtools groupby -g 1-3 -c 7 -o min > ${outdir}/${sample}_cpg_q40.tmp.bed) & pid2=$!

--- a/scripts/QC.sh
+++ b/scripts/QC.sh
@@ -149,7 +149,7 @@ function biscuitQC {
         (bedtools intersect -sorted -wo -b ${outdir}/${sample}_genomecov_q40.tmp.bed -a stdin < "$tmp_dir/f2" | bedtools groupby -g 1-3 -c 7 -o min > ${outdir}/${sample}_cpg_q40.tmp.bed) & pid2=$!
         
         # Stream data into the named pipes
-        cat ${BISCUIT_CPGS} | tee $tmp_dir/f1" "$tmp_dir/f2" >/dev/null &
+        cat ${BISCUIT_CPGS} | tee "$tmp_dir/f1" "$tmp_dir/f2" >/dev/null &
         
         # Wait for all subprocesses to complete, then clean up the pipes we created
         wait $pid1 $pid2 


### PR DESCRIPTION
I recently ran into a bug using a new version of GNU parallel. I quickly developed a bit of annoyance when I had a difficult time finding a changelog for parallel. I believe the 'tee' command should work just as well and it's a lot easier to read. 

(edit) OK, maybe it's not as easy to read anymore... :-D