### PR TITLE
fix keep tmp files option

### DIFF
--- a/scripts/QC.sh
+++ b/scripts/QC.sh
@@ -490,7 +490,7 @@ run_cov_qc=true
 # Process command line arguments
 OPTS=$(getopt \
     --options hsv:o:kn \
-    --long help,single-end,vcf:,outdir:,keep-bed-files,no-cov-qc \
+    --long help,single-end,vcf:,outdir:,keep-tmp-files,no-cov-qc \
     --name "$(basename "$0")" \
     -- "$@"
 )


### PR DESCRIPTION
Fixed a quick typo that caused the `--keep-tmp-files` option not to work.