### PR TITLE
Fix finding libdeflate

### DIFF
--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -26,24 +26,21 @@ jobs:
     # - name: Run tests
     #   run: make check
 
-  # macOS build is now failing because it can't find libdeflate. The only issue
-  # is that it shouldn't need to find libdefalte, because htslib isn't built
-  # with libdeflate. Will stop macOS build checks for the time being (15 Apr 2025).
-  #build-mac:
-  #  name: Check macOS Build
+  build-mac:
+    name: Check macOS Build
 
-  #  # macos-latest is now ARM-only, macos-13 is the most recent version that supports x86-64
-  #  runs-on: macos-13
+    # macos-latest is now ARM-only, macos-13 is the most recent version that supports x86-64
+    runs-on: macos-13
 
-  #  steps:
-  #  - uses: actions/checkout@v3
+    steps:
+    - uses: actions/checkout@v3
 
-  #  - name: Check build
-  #    run: mkdir build && cd build && cmake ../ -DCMAKE_INSTALL_PREFIX=../ && make && make install
+    - name: Check build
+      run: mkdir build && cd build && cmake ../ -DCMAKE_INSTALL_PREFIX=../ && make && make install
 
-  #  - name: Install Check
-  #    run: ./bin/biscuit version
+    - name: Install Check
+      run: ./bin/biscuit version
 
-  #  # These haven't been generated yet, so uncomment when ready
-  #  # - name: Run tests
-  #  #   run: make check
+    # These haven't been generated yet, so uncomment when ready
+    # - name: Run tests
+    #   run: make check

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,10 +72,10 @@ ExternalProject_Add(sgsl
 find_package(LIBDEFLATE)
 if(LIBDEFLATE_FOUND)
     set(LIBDEFLATE_FLAG "--with-libdeflate")
-    message(STATUS "found libdeflate: ${DEFLATE_INCLUDE_DIR} ${LIBDEFLATE_FLAG}")
+    message(STATUS "found a system libdeflate. will build htslib with libdeflate")
 else()
     set(LIBDEFLATE_FLAG "--without-libdeflate")
-    message(STATUS "could not find libdeflate: ${DEFLATE_INCLUDE_DIR} ${LIBDEFLATE_FLAG}")
+    message(STATUS "could not find a system libdeflate. will build htslib without libdeflate")
 endif()
 
 # htslib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,9 @@ project(biscuit
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED True)
 
+# Find module paths
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
+
 # Standard installation paths
 include(GNUInstallDirs)
 
@@ -65,6 +68,16 @@ ExternalProject_Add(sgsl
     BUILD_IN_SOURCE 1
     )
 
+# libdeflate
+find_package(LIBDEFLATE)
+if(LIBDEFLATE_FOUND)
+    set(LIBDEFLATE_FLAG "--with-libdeflate")
+    message(STATUS "found libdeflate: ${DEFLATE_INCLUDE_DIR} ${LIBDEFLATE_FLAG}")
+else()
+    set(LIBDEFLATE_FLAG "--without-libdeflate")
+    message(STATUS "could not find libdeflate: ${DEFLATE_INCLUDE_DIR} ${LIBDEFLATE_FLAG}")
+endif()
+
 # htslib
 find_package(CURL REQUIRED)
 set(SHA_CHECK ${SCRIPT_DIR}/confirm_download.sh)
@@ -84,7 +97,7 @@ if(APPLE)
             mv -f ${htslib_base} htslib
         SOURCE_DIR ${LIB_DIR}/htslib
         INSTALL_DIR ${LIB_DIR}/install
-        CONFIGURE_COMMAND ${LIB_DIR}/htslib/configure --prefix=<INSTALL_DIR> --disable-bz2 --disable-lzma --disable-libcurl
+        CONFIGURE_COMMAND ${LIB_DIR}/htslib/configure --prefix=<INSTALL_DIR> --disable-bz2 --disable-lzma --disable-libcurl ${LIBDEFLATE_FLAG}
         BUILD_COMMAND make lib-static
         INSTALL_COMMAND ""
         BUILD_IN_SOURCE 1
@@ -100,7 +113,7 @@ else()
             mv -f ${htslib_base} htslib
         SOURCE_DIR ${LIB_DIR}/htslib
         INSTALL_DIR ${LIB_DIR}/install
-        CONFIGURE_COMMAND ${LIB_DIR}/htslib/configure --prefix=<INSTALL_DIR> --disable-bz2 --disable-lzma --disable-libcurl
+        CONFIGURE_COMMAND ${LIB_DIR}/htslib/configure --prefix=<INSTALL_DIR> --disable-bz2 --disable-lzma --disable-libcurl ${LIBDEFLATE_FLAG}
         BUILD_COMMAND make lib-static
         INSTALL_COMMAND ""
         BUILD_IN_SOURCE 1

--- a/cmake/FindLIBDEFLATE.cmake
+++ b/cmake/FindLIBDEFLATE.cmake
@@ -1,28 +1,33 @@
+# Search for libdeflate using pkg-config
 if(UNIX)
     find_package(PkgConfig QUIET)
-    # pkg-config support added in libdeflate v1.9
     pkg_check_modules(_LIBDEFLATE QUIET libdeflate)
 else()
-    message(FATAL_ERROR "BISCUIT only works on Unix systems")
+    message(FATAL_ERROR "BISCUIT currently only works on Unix systems")
 endif()
 
+# Get include directory and shared library path
 find_path(LIBDEFLATE_INCLUDE_DIR
     NAMES libdeflate.h
-    HINTS ${_LIBDEFLATE_INCLUDEDIR})
+    HINTS ${_LIBDEFLATE_INCLUDEDIR}
+    )
 find_library(LIBDEFLATE_LIBRARY
     NAMES deflate
-    HINTS ${_LIBDEFLATE_LIBDIR})
+    HINTS ${_LIBDEFLATE_LIBDIR}
+    )
 
+# Set variables for use in CMakeLists files
 set(LIBDEFLATE_INCLUDE_DIRS ${LIBDEFLATE_INCLUDE_DIR})
 set(LIBDEFLATE_LIBRARIES ${LIBDEFLATE_LIBRARY})
 
+# Pull version from pkg-config if possible, otherwise pull from libdeflate header
 if(_LIBDEFLATE_VERSION)
-        set(LIBDEFLATE_VERSION ${_LIBDEFLATE_VERSION})
+    set(LIBDEFLATE_VERSION ${_LIBDEFLATE_VERSION})
 elseif(LIBDEFLATE_INCLUDE_DIR)
-        file(STRINGS "${LIBDEFLATE_INCLUDE_DIR}/libdeflate.h" LIBDEFLATE_VERSION_STR
-                        REGEX "^#define[\t ]+LIBDEFLATE_VERSION_STRING[\t ]+\"[^\"]+\"")
-        if(LIBDEFLATE_VERSION_STR MATCHES "\"([^\"]+)\"")
-                set(LIBDEFLATE_VERSION "${CMAKE_MATCH_1}")
+    file(STRINGS "${LIBDEFLATE_INCLUDE_DIR}/libdeflate.h" LIBDEFLATE_VERSION_STR
+        REGEX "^#define[\t ]+LIBDEFLATE_VERSION_STRING[\t ]+\"[^\"]+\"")
+    if(LIBDEFLATE_VERSION_STR MATCHES "\"([^\"]+)\"")
+        set(LIBDEFLATE_VERSION "${CMAKE_MATCH_1}")
     endif()
 endif()
 
@@ -30,8 +35,8 @@ include(FindPackageHandleStandardArgs)
 
 find_package_handle_standard_args(LIBDEFLATE
     REQUIRED_VARS
-                LIBDEFLATE_INCLUDE_DIR
-                LIBDEFLATE_LIBRARY
+        LIBDEFLATE_INCLUDE_DIR
+        LIBDEFLATE_LIBRARY
     VERSION_VAR LIBDEFLATE_VERSION)
 
 mark_as_advanced(LIBDEFLATE_INCLUDE_DIR LIBDEFLATE_LIBRARY)

--- a/cmake/FindLIBDEFLATE.cmake
+++ b/cmake/FindLIBDEFLATE.cmake
@@ -1,0 +1,37 @@
+if(UNIX)
+    find_package(PkgConfig QUIET)
+    # pkg-config support added in libdeflate v1.9
+    pkg_check_modules(_LIBDEFLATE QUIET libdeflate)
+else()
+    message(FATAL_ERROR "BISCUIT only works on Unix systems")
+endif()
+
+find_path(LIBDEFLATE_INCLUDE_DIR
+    NAMES libdeflate.h
+    HINTS ${_LIBDEFLATE_INCLUDEDIR})
+find_library(LIBDEFLATE_LIBRARY
+    NAMES deflate
+    HINTS ${_LIBDEFLATE_LIBDIR})
+
+set(LIBDEFLATE_INCLUDE_DIRS ${LIBDEFLATE_INCLUDE_DIR})
+set(LIBDEFLATE_LIBRARIES ${LIBDEFLATE_LIBRARY})
+
+if(_LIBDEFLATE_VERSION)
+        set(LIBDEFLATE_VERSION ${_LIBDEFLATE_VERSION})
+elseif(LIBDEFLATE_INCLUDE_DIR)
+        file(STRINGS "${LIBDEFLATE_INCLUDE_DIR}/libdeflate.h" LIBDEFLATE_VERSION_STR
+                        REGEX "^#define[\t ]+LIBDEFLATE_VERSION_STRING[\t ]+\"[^\"]+\"")
+        if(LIBDEFLATE_VERSION_STR MATCHES "\"([^\"]+)\"")
+                set(LIBDEFLATE_VERSION "${CMAKE_MATCH_1}")
+    endif()
+endif()
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(LIBDEFLATE
+    REQUIRED_VARS
+                LIBDEFLATE_INCLUDE_DIR
+                LIBDEFLATE_LIBRARY
+    VERSION_VAR LIBDEFLATE_VERSION)
+
+mark_as_advanced(LIBDEFLATE_INCLUDE_DIR LIBDEFLATE_LIBRARY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,3 +53,8 @@ if(Curses_FOUND)
 else()
     message(FATAL_ERROR "ncurses not found. Required for compilation")
 endif(Curses_FOUND)
+
+if(LIBDEFLATE_FOUND)
+    include_directories(${LIBDEFLATE_INCLUDE_DIRS})
+    target_link_libraries(biscuit ${LIBDEFLATE_LIBRARIES})
+endif()


### PR DESCRIPTION
`htslib` by default will try to build against `libdeflate` if not explicitly told to build without it. If `htslib` found a system installation of `libdeflate`, BISCUIT's compilation would fail at the linking stage due to undefined symbols from `libdeflate`. Therefore, BISCUIT will now search for a `libdeflate` installation using `pkg-config`. If it can find one, it will build `htslib` with `libdeflate` and appropriately link the shared library when compiling BISCUIT. If it can't find a `libdeflate` installation, it will explicitly tell `htslib` to build without `libdeflate` and skip linking to `libdeflate` when compiling BISCUIT.