### PR TITLE
Two fixes: alt contig finding and insert size calculation

### DIFF
--- a/lib/aln/align.c
+++ b/lib/aln/align.c
@@ -181,46 +181,29 @@ static void update_a(mem_opt_t *opt, const mem_opt_t *opt0) {
   }
 }
 
-static void infer_alt_chromosomes(bntseq_t *bns) {
-  // logic: if the chr1,...chr22,chrX,chrY,chrM,
-  // then mark everything with chrUn and _random and _hap as alt
+// ALT status is taken solely from the <fai-index base>.alt file (loaded in
+// bns_restore). We deliberately do NOT guess ALT status from contig names:
+// unplaced (chrUn_*) and unlocalized (*_random) contigs are part of the primary
+// assembly, not ALT contigs. Treating them as ALT forces their reads onto the
+// primary chromosomes and produces mismappings and false signal.
+//
+// This helper only warns when the reference appears to contain genuine
+// alternate-locus/haplotype contigs (_alt/_hap) but no .alt file marked any
+// contig as ALT, so the user knows to supply one.
+static void warn_missing_alt_file(bntseq_t *bns) {
   int i;
-  for (i=0; i<bns->n_seqs; ++i) if (bns->anns[i].is_alt) break;
-  if (i<bns->n_seqs) return;    // skip if alt info is present
-  
-  int found[25]; memset(found, 0, 25*sizeof(int));
-  for (i=0; i<bns->n_seqs; ++i) {
-    if (strncmp(bns->anns[i].name, "chr", 3) == 0) {
-      if (strlen(bns->anns[i].name) == 4) {
-        if (toupper(bns->anns[i].name[3]) == 'X') found[22] = 1;
-        else if (toupper(bns->anns[i].name[3]) == 'Y') found[23] = 1;
-        else if (toupper(bns->anns[i].name[3]) == 'M') found[24] = 1;
-        else if (isdigit(bns->anns[i].name[3])) {
-          int n = bns->anns[i].name[3]-'0';
-          if (n>0 && n<=22) found[n-1] = 1;
-        }
-      } else if (strlen(bns->anns[i].name) == 5 &&
-                 isdigit(bns->anns[i].name[3]) && isdigit(bns->anns[i].name[4])) {
-        int n = atoi(bns->anns[i].name+3);
-        if (n>0 && n<=22) found[n-1] = 1;
-      }
-    }
-  }
+  for (i=0; i<bns->n_seqs; ++i) if (bns->anns[i].is_alt) return; // .alt file present
 
-  int n;
-  for (i=n=0; i<25; ++i) if (found[i]) ++n;
-  if (n < 20) return; // should take care of human and mouse
-  
-  for (i=0; i<bns->n_seqs; ++i) {
-    if (strncmp(bns->anns[i].name, "chrUn", 5)==0 || 
-        strstr(bns->anns[i].name, "_random") || 
-        strstr(bns->anns[i].name, "_hap") ||
-        strstr(bns->anns[i].name, "_alt")) {
-      bns->anns[i].is_alt = 1;
-      if (bwa_verbose >= 4)
-        fprintf(stderr, "[M:%s] Set %s as ALT.\n", __func__, bns->anns[i].name);
-    }
-  }
+  int n_alt_like = 0;
+  for (i=0; i<bns->n_seqs; ++i)
+    if (strstr(bns->anns[i].name, "_alt") || strstr(bns->anns[i].name, "_hap"))
+      ++n_alt_like;
+
+  if (n_alt_like > 0)
+    fprintf(stderr, "[M::%s] %d contig(s) look like alternate haplotypes/loci "
+            "(_alt/_hap) but no <fai-index base>.alt file was found; they will be "
+            "treated as part of the primary assembly. Supply a .alt file to mark "
+            "ALT contigs.\n", __func__, n_alt_like);
 }
 
 int usage(mem_opt_t *opt) {
@@ -282,7 +265,6 @@ int usage(mem_opt_t *opt) {
     fprintf(stderr, "Input/output options:\n");
     fprintf(stderr, "    -1 STR          Align a single read STR\n");
     fprintf(stderr, "    -2 STR          Align a read STR paired with -1 read\n");
-    fprintf(stderr, "    -i              Turn off autoinference of ALT chromosomes\n");
     fprintf(stderr, "    -p              Smart pairing (ignores in2.fq)\n");
     fprintf(stderr, "    -R STR          Read group header line (such as '@RG\\tID:foo\\tSM:bar')\n");
     fprintf(stderr, "    -F              Suppress SAM header output\n");
@@ -334,16 +316,14 @@ int main_align(int argc, char *argv[]) {
   aux.opt = opt = mem_opt_init();
   opt->flag |= MEM_F_NO_MULTI;  /* WZBS */
   memset(&opt0, 0, sizeof(mem_opt_t));
-  int auto_infer_alt_chrom = 1;
   if (argc < 2) return usage(opt);
-  while ((c = getopt(argc, argv, ":@:1:2:3:5:9ab:c:d:ef:g:hijk:m:pqr:s:v:w:x:y:z:A:B:CD:E:FG:H:I:J:K:L:MN:O:PQ:R:ST:U:VW:X:Y")) >= 0) {
+  while ((c = getopt(argc, argv, ":@:1:2:3:5:9ab:c:d:ef:g:hjk:m:pqr:s:v:w:x:y:z:A:B:CD:E:FG:H:I:J:K:L:MN:O:PQ:R:ST:U:VW:X:Y")) >= 0) {
       if (c == 'k') opt->min_seed_len = atoi(optarg), opt0.min_seed_len = 1;
       else if (c == '1') aux._seq1 = strdup(optarg);
       else if (c == '2') aux._seq2 = strdup(optarg);
       else if (c == 'x') mode = optarg;
       else if (c == 'b') opt->parent = atoi(optarg);   /* targeting parent or daughter */
       else if (c == 'f') opt->bsstrand = atoi(optarg); /* targeting BSW or BSC */
-      else if (c == 'i') auto_infer_alt_chrom = 0; // turn off auto-inference of alt-chromosomes
       else if (c == 'w') opt->w = atoi(optarg), opt0.w = 1;
       else if (c == 'A') opt->a = atoi(optarg), opt0.a = 1;
       else if (c == 'B') opt->b = atoi(optarg), opt0.b = 1;
@@ -527,9 +507,9 @@ int main_align(int argc, char *argv[]) {
   } else if (bwa_verbose >= 3)
     fprintf(stderr, "[M::%s] load the bwa index from shared memory\n", __func__);
 
-  // infer alternative chromosomes from name
-  if (auto_infer_alt_chrom) infer_alt_chromosomes(aux.idx->bns);
-  
+  // ALT status comes only from the .alt file; warn if it looks missing
+  warn_missing_alt_file(aux.idx->bns);
+
   if (ignore_alt)
     for (i = 0; i < aux.idx->bns->n_seqs; ++i)
       aux.idx->bns->anns[i].is_alt = 0;

--- a/lib/aln/align.c
+++ b/lib/aln/align.c
@@ -415,7 +415,6 @@ int main_align(int argc, char *argv[]) {
       } else if (c == 'I') { // specify the insert size distribution
           mem_pestat_t *pes = calloc(1, sizeof(mem_pestat_t));
           pes->avg = strtod(optarg, &p);
-          pes->avg = strtod(optarg, &p);
           pes->std = pes->avg * .1;
           if (*p != 0 && ispunct(*p) && isdigit(p[1]))
               pes->std = strtod(p+1, &p);

--- a/lib/aln/bntseq.c
+++ b/lib/aln/bntseq.c
@@ -40,7 +40,7 @@
 KSEQ_DECLARE(gzFile)
 
 #include "khash.h"
-KHASH_MAP_INIT_STR(str, int)
+KHASH_MAP_INIT_STR(names, int)
 
 #ifdef USE_MALLOC_WRAPPERS
 #  include "malloc_wrap.h"
@@ -172,47 +172,57 @@ bntseq_t *bns_restore_core(const char *ann_filename, const char* amb_filename, c
 }
 
 bntseq_t *bns_restore(const char *prefix) {
-  char ann_filename[1024], amb_filename[1024], pac_filename[1024], alt_filename[1024];
-  FILE *fp;
-  bntseq_t *bns;
+    char ann_filename[1024], amb_filename[1024], pac_filename[1024], alt_filename[1024];
+    FILE *fp;
+    bntseq_t *bns;
 
-  /**** bisulfite adaptation ****/
-  /* strcat(strcpy(ann_filename, prefix), ".ann"); */
-  /* strcat(strcpy(amb_filename, prefix), ".amb"); */
-  /* strcat(strcpy(pac_filename, prefix), ".pac"); */
-  strcat(strcpy(ann_filename, prefix), ".bis.ann");
-  strcat(strcpy(amb_filename, prefix), ".bis.amb");
-  strcat(strcpy(pac_filename, prefix), ".bis.pac");
+    /**** bisulfite adaptation ****/
+    strcat(strcpy(ann_filename, prefix), ".bis.ann");
+    strcat(strcpy(amb_filename, prefix), ".bis.amb");
+    strcat(strcpy(pac_filename, prefix), ".bis.pac");
 
-  bns = bns_restore_core(ann_filename, amb_filename, pac_filename);
-  if (bns == 0) return 0;
-  if ((fp = fopen(strcat(strcpy(alt_filename, prefix), ".alt"), "r")) != 0) { // read .alt file if present
-    char str[1024];
-    khash_t(str) *h;
-    int c, i, absent;
-    khint_t k;
-    h = kh_init(str);
-    for (i = 0; i < bns->n_seqs; ++i) {
-      k = kh_put(str, h, bns->anns[i].name, &absent);
-      kh_val(h, k) = i;
-    }
-    i = 0;
-    while ((c = fgetc(fp)) != EOF) {
-      if (c == '\t' || c == '\n' || c == '\r') {
-        str[i] = 0;
-        if (str[0] != '@') {
-          k = kh_get(str, h, str);
-          if (k != kh_end(h))
-            bns->anns[kh_val(h, k)].is_alt = 1;
+    bns = bns_restore_core(ann_filename, amb_filename, pac_filename);
+    if (bns == 0) return 0;
+    if ((fp = fopen(strcat(strcpy(alt_filename, prefix), ".alt"), "r")) != 0) { // read .alt file if present
+        char str[1024];
+        khash_t(names) *h;
+        int c, i, absent;
+        khint_t k;
+        h = kh_init(names);
+        for (i = 0; i < bns->n_seqs; ++i) {
+            k = kh_put(names, h, bns->anns[i].name, &absent);
+            kh_val(h, k) = i;
         }
-        while (c != '\n' && c != EOF) c = fgetc(fp);
         i = 0;
-      } else str[i++] = c; // FIXME: potential segfault here
+        while ((c = fgetc(fp)) != EOF) {
+            if (c == '\t' || c == '\n' || c == '\r') {
+                str[i] = 0;
+                // If .alt file is built by grepping for "_alt" or "_hap" from a FASTA or FASTQ file,
+                // then we need to shift the start point for the string so we can correctly search
+                // for the name from the index, which stripped these characters off
+                if (str[0] == '@' || str[0] == '>') {
+                    k = kh_get(names, h, str+1);
+                } else {
+                    k = kh_get(names, h, str);
+                }
+                if (k != kh_end(h)) {
+                    bns->anns[kh_val(h, k)].is_alt = 1;
+                }
+                while (c != '\n' && c != EOF) c = fgetc(fp);
+                i = 0;
+            } else {
+                // Resolves lingering potential seg fault comment
+                if (i >= 1022) {
+                    fprintf(stderr, "[E::%s] sequence name longer than 1023 characters. Abort!\n", __func__);
+                    exit(1);
+                }
+                str[i++] = c;
+            }
+        }
+        kh_destroy(names, h);
+        fclose(fp);
     }
-    kh_destroy(str, h);
-    fclose(fp);
-  }
-  return bns;
+    return bns;
 }
 
 void bns_destroy(bntseq_t *bns) {

--- a/lib/aln/bwamem.c
+++ b/lib/aln/bwamem.c
@@ -398,7 +398,7 @@ static void bis_worker2(void *data, long i, int tid) {
       printf("\n=====> [%s] Finalizing PE read '%s' <=====\n",
              __func__, w->seqs[i<<1|0].name);
 
-    if (!(w->opt->flag & MEM_F_NO_RESCUE)) 
+    if (!(w->opt->flag & MEM_F_NO_RESCUE) && !w->pes.failed)
       mem_alnreg_matesw(w->opt, w->bns, w->pac,
                         w->pes, &w->seqs[i<<1], &w->regs[i<<1]);
 

--- a/lib/aln/mem_alnreg.h
+++ b/lib/aln/mem_alnreg.h
@@ -73,13 +73,20 @@ typedef struct {
 
 // note: pos1 == isrev1 ? end1 : beg1; pos2 == isrev2 ? end2 : beg2
 static inline int mem_infer_isize(int64_t pos1, int64_t pos2, int isrev1, int isrev2, int len1, int len2, int64_t *isize) {
+  // For a reverse-strand mate, the caller maps its position through
+  // (l_pac<<1)-1-rb, which already yields the rightmost (far) forward
+  // coordinate of the fragment. The forward mate's position is the leftmost.
+  // The template length is therefore simply the difference between the two; do
+  // NOT add the read length, or the insert size is overestimated by one read
+  // length (len1/len2 are kept for the signature but intentionally unused).
+  (void)len1; (void)len2;
   if (isrev1 && !isrev2) {
-    *isize = pos1 - pos2 + len1;
+    *isize = pos1 - pos2;
     return 1;
   } else if (isrev2 && !isrev1) {
-    *isize = pos2 - pos1 + len2;
+    *isize = pos2 - pos1;
     return 1;
-  } else return 0;  
+  } else return 0;
 }
 
 // return 1 (success) or 0 (failure)

--- a/lib/aln/mem_alnreg.h
+++ b/lib/aln/mem_alnreg.h
@@ -71,20 +71,17 @@ typedef struct {
   size_t n_pri; // number of regions on primary chromosomes
 } mem_alnreg_v;
 
-// note: pos1 == isrev1 ? end1 : beg1; pos2 == isrev2 ? end2 : beg2
+// pos1/pos2 must be the leftmost (SAM POS) forward coordinate of each mate,
+// for both strands (see mem_alnreg_isize below and region_depos, which mem_pair
+// uses). The fragment spans from the forward mate's leftmost coordinate to the
+// reverse mate's rightmost coordinate, so the reverse mate contributes its own
+// length. len1/len2 are the (query) read lengths.
 static inline int mem_infer_isize(int64_t pos1, int64_t pos2, int isrev1, int isrev2, int len1, int len2, int64_t *isize) {
-  // For a reverse-strand mate, the caller maps its position through
-  // (l_pac<<1)-1-rb, which already yields the rightmost (far) forward
-  // coordinate of the fragment. The forward mate's position is the leftmost.
-  // The template length is therefore simply the difference between the two; do
-  // NOT add the read length, or the insert size is overestimated by one read
-  // length (len1/len2 are kept for the signature but intentionally unused).
-  (void)len1; (void)len2;
   if (isrev1 && !isrev2) {
-    *isize = pos1 - pos2;
+    *isize = pos1 - pos2 + len1;
     return 1;
   } else if (isrev2 && !isrev1) {
-    *isize = pos2 - pos1;
+    *isize = pos2 - pos1 + len2;
     return 1;
   } else return 0;
 }
@@ -94,8 +91,12 @@ static inline int mem_alnreg_isize(const bntseq_t *bns, const mem_alnreg_t *r1, 
   if (r1->rid != r2->rid) return 0;
   int isrev1 = r1->rb > bns->l_pac;
   int isrev2 = r2->rb > bns->l_pac;
-  int64_t pos1 = isrev1 ? (bns->l_pac<<1) - 1 - r1->rb : r1->rb;
-  int64_t pos2 = isrev2 ? (bns->l_pac<<1) - 1 - r2->rb : r2->rb;
+  // leftmost (SAM POS) forward coordinate; for a reverse mate this is
+  // (l_pac<<1)-1-(re-1), matching region_depos used by mem_pair. Using rb here
+  // instead would yield the rightmost coordinate and, combined with the +len in
+  // mem_infer_isize, overestimate the insert size by one read length.
+  int64_t pos1 = isrev1 ? (bns->l_pac<<1) - 1 - (r1->re - 1) : r1->rb;
+  int64_t pos2 = isrev2 ? (bns->l_pac<<1) - 1 - (r2->re - 1) : r2->rb;
   return mem_infer_isize(pos1, pos2, isrev1, isrev2, (int64_t) (r1->qe-r1->qb), (int64_t) (r2->qe-r2->qb), isize);
 }
 

--- a/lib/aln/mem_alnreg_format.c
+++ b/lib/aln/mem_alnreg_format.c
@@ -579,6 +579,8 @@ void mem_reg2sam_pe(
   
    if (opt->flag & MEM_F_NOPAIRING)
       return mem_reg2sam_pe_nopairing(opt, bns, pac, s, regs_pair, pes);
+   if (pes.failed) // insert size could not be inferred (too few pairs, no -I)
+      return mem_reg2sam_pe_nopairing(opt, bns, pac, s, regs_pair, pes);
    if (regs_pair[0].n_pri == 0 || regs_pair[1].n_pri == 0)
       return mem_reg2sam_pe_nopairing(opt, bns, pac, s, regs_pair, pes);
 


### PR DESCRIPTION
Based on the issues raised in #76, BISCUIT now uses only the `.alt` file for setting alt contigs for alignment. The biggest effect is that unplaced/unlocalized contigs will no longer be treated as alt and will be given the same footing as canonical chromosomes during alignment.

When addressing this issue, a bug was found in the calculation of the insert size when performing the mate rescue step. This has been fixed in this PR.